### PR TITLE
PartX: simplified TPL step 2 design

### DIFF
--- a/PipelineImplementations/PartX/TplAsyncPipeline.cs
+++ b/PipelineImplementations/PartX/TplAsyncPipeline.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+namespace PipelineImplementations.PartX
+{
+    public class TplAsyncPipeline<TInput, TOutput>
+    {
+        readonly ITargetBlock<TInput> _firstStep;
+        readonly Task<TOutput> _completionTask;
+
+        public TplAsyncPipeline(ITargetBlock<TInput> firstStep, Task<TOutput> completionTask)
+        {
+            _firstStep = firstStep;
+             _completionTask = completionTask;
+        }
+
+        public async Task<TOutput> Execute(TInput input)
+        {
+            await _firstStep.SendAsync(input);
+            
+            var result =  await _completionTask;
+            return result;
+        }
+    }
+}

--- a/PipelineImplementations/PartX/TplAsyncPipelineBuilder.cs
+++ b/PipelineImplementations/PartX/TplAsyncPipelineBuilder.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+namespace PipelineImplementations.PartX
+{
+    public class TplAsyncPipelineBuilder<TInput> : TplAsyncPipelineBuilder<TInput, TInput> { }
+
+    public class TplAsyncPipelineBuilder<TFirstInput, TCurrentInput>
+    {
+        private IDataflowBlock _firstStep;
+        private IDataflowBlock _lastStep;        
+
+        public TplAsyncPipelineBuilder() : this(null, null)
+        {
+
+        }
+        private TplAsyncPipelineBuilder(IDataflowBlock firstStep, IDataflowBlock lastStep)
+        {
+            _firstStep = firstStep;
+            _lastStep = lastStep;
+        }
+
+        private void PushStep(IDataflowBlock step){
+            _firstStep = _firstStep ?? step;
+            _lastStep = step;
+        }
+
+        public TplAsyncPipelineBuilder<TFirstInput, TOutput> AddStep<TOutput>(Func<TCurrentInput, Task<TOutput>> transformAsync)
+        {
+            switch (_lastStep)
+            {
+                case ISourceBlock<Task<TCurrentInput>> asyncSourceBlock:
+                    var newAsyncBlock = new TransformBlock<Task<TCurrentInput>, Task<TOutput>>(async (input) => await transformAsync(await input));
+                    asyncSourceBlock.LinkTo(newAsyncBlock);
+                    PushStep(newAsyncBlock);
+                    break;
+
+                case null:
+                case ISourceBlock<TCurrentInput> sourceBlock:
+                    var newBlock = new TransformBlock<TCurrentInput, Task<TOutput>>(async (input) => await transformAsync(input));
+                    PushStep(newBlock);
+                    break;
+            }
+            return new TplAsyncPipelineBuilder<TFirstInput, TOutput>(_firstStep, _lastStep);
+        }
+
+        public TplAsyncPipelineBuilder<TFirstInput, TOutput> AddStep<TOutput>(Func<TCurrentInput, TOutput> transform)
+            => AddStep(input => Task.FromResult(transform(input)));
+
+        public TplAsyncPipeline<TFirstInput, TCurrentInput> Build()
+        {
+            var completionTask = new TaskCompletionSource<TCurrentInput>();
+            var firstStep = _firstStep as ITargetBlock<TFirstInput>;
+
+            AddStep(input =>
+            {
+                completionTask.SetResult(input);
+                return input;
+            });
+
+            return new TplAsyncPipeline<TFirstInput, TCurrentInput>(firstStep, completionTask.Task);
+        }
+    }
+}

--- a/PipelineImplementations/PartX/TplAsyncPipelineBuilder.cs
+++ b/PipelineImplementations/PartX/TplAsyncPipelineBuilder.cs
@@ -30,15 +30,20 @@ namespace PipelineImplementations.PartX
         {
             switch (_lastStep)
             {
+                case null:
+                    var initialBlock = new TransformBlock<TCurrentInput, Task<TOutput>>(async (input) => await transformAsync(input));
+                    PushStep(initialBlock);
+                    break;
+
                 case ISourceBlock<Task<TCurrentInput>> asyncSourceBlock:
                     var newAsyncBlock = new TransformBlock<Task<TCurrentInput>, Task<TOutput>>(async (input) => await transformAsync(await input));
                     asyncSourceBlock.LinkTo(newAsyncBlock);
                     PushStep(newAsyncBlock);
                     break;
 
-                case null:
                 case ISourceBlock<TCurrentInput> sourceBlock:
                     var newBlock = new TransformBlock<TCurrentInput, Task<TOutput>>(async (input) => await transformAsync(input));
+                    sourceBlock.LinkTo(newBlock);
                     PushStep(newBlock);
                     break;
             }

--- a/PipelineImplementations/PartX/TplAsyncPipelineBuilder.cs
+++ b/PipelineImplementations/PartX/TplAsyncPipelineBuilder.cs
@@ -4,49 +4,58 @@ using System.Threading.Tasks.Dataflow;
 
 namespace PipelineImplementations.PartX
 {
-    public class TplAsyncPipelineBuilder<TInput> : TplAsyncPipelineBuilder<TInput, TInput> { }
+    public class TplAsyncPipelineBuilder<TInput> : TplAsyncPipelineBuilder<TInput, TInput>
+    {
+    }
 
     public class TplAsyncPipelineBuilder<TFirstInput, TCurrentInput>
     {
         private IDataflowBlock _firstStep;
-        private IDataflowBlock _lastStep;        
+        private IDataflowBlock _lastStep;
 
         public TplAsyncPipelineBuilder() : this(null, null)
         {
-
         }
+
         private TplAsyncPipelineBuilder(IDataflowBlock firstStep, IDataflowBlock lastStep)
         {
             _firstStep = firstStep;
             _lastStep = lastStep;
         }
 
-        private void PushStep(IDataflowBlock step){
+        private void PushStep(IDataflowBlock step)
+        {
             _firstStep = _firstStep ?? step;
             _lastStep = step;
         }
 
-        public TplAsyncPipelineBuilder<TFirstInput, TOutput> AddStep<TOutput>(Func<TCurrentInput, Task<TOutput>> transformAsync)
+        public TplAsyncPipelineBuilder<TFirstInput, TOutput> AddStep<TOutput>(
+            Func<TCurrentInput, Task<TOutput>> transformAsync)
         {
             switch (_lastStep)
             {
                 case null:
-                    var initialBlock = new TransformBlock<TCurrentInput, Task<TOutput>>(async (input) => await transformAsync(input));
+                    var initialBlock =
+                        new TransformBlock<TCurrentInput, Task<TOutput>>(async (input) => await transformAsync(input));
                     PushStep(initialBlock);
                     break;
 
                 case ISourceBlock<Task<TCurrentInput>> asyncSourceBlock:
-                    var newAsyncBlock = new TransformBlock<Task<TCurrentInput>, Task<TOutput>>(async (input) => await transformAsync(await input));
+                    var newAsyncBlock =
+                        new TransformBlock<Task<TCurrentInput>, Task<TOutput>>(async (input) =>
+                            await transformAsync(await input));
                     asyncSourceBlock.LinkTo(newAsyncBlock);
                     PushStep(newAsyncBlock);
                     break;
 
                 case ISourceBlock<TCurrentInput> sourceBlock:
-                    var newBlock = new TransformBlock<TCurrentInput, Task<TOutput>>(async (input) => await transformAsync(input));
+                    var newBlock =
+                        new TransformBlock<TCurrentInput, Task<TOutput>>(async (input) => await transformAsync(input));
                     sourceBlock.LinkTo(newBlock);
                     PushStep(newBlock);
                     break;
             }
+
             return new TplAsyncPipelineBuilder<TFirstInput, TOutput>(_firstStep, _lastStep);
         }
 

--- a/PipelineImplementations/PartX/Usage.cs
+++ b/PipelineImplementations/PartX/Usage.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PipelineImplementations.PartX
+{
+    public static class Usage
+    {
+        public static async Task Use()
+        {
+            const string exampleStr = "The pipeline pattern is the best pattern";
+
+            var mgPipeline = new TplAsyncPipelineBuilder<string>()
+                .AddStep(str => FindMostCommonAsync(str))
+                .AddStep(str => CountChars(str))
+                .AddStep(len => IsOdd(len))
+                .Build();
+
+            var result = await mgPipeline.Execute(exampleStr);
+            Console.WriteLine($"MG pipeline: {result}");
+        }
+
+        private static async Task<string> FindMostCommonAsync(string input)
+        {
+            await Task.Delay(10);
+            return input.Split(' ')
+                .GroupBy(word => word)
+                .OrderBy(group => group.Count())
+                .Last()
+                .Key;
+        }
+
+        private static int CountChars(string input) => input.Length;
+
+        private static bool IsOdd(int number) => number % 2 == 1;
+    }
+}

--- a/PipelineImplementations/PipelineImplementations.csproj
+++ b/PipelineImplementations/PipelineImplementations.csproj
@@ -88,6 +88,9 @@
     <Compile Include="PartN\IPipelineBuilder.cs" />
     <Compile Include="PartN\IPipelineBuilderStep.cs" />
     <Compile Include="PartN\UsagePartN.cs" />
+    <Compile Include="PartX\TplAsyncPipeline.cs" />
+    <Compile Include="PartX\TplAsyncPipelineBuilder.cs" />
+    <Compile Include="PartX\Usage.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils.cs" />

--- a/PipelineImplementations/Program.cs
+++ b/PipelineImplementations/Program.cs
@@ -22,6 +22,7 @@ namespace PipelineImplementations
 
             //await UsagePartN.Use2();
             UsagePart3.Use();
+            await PartX.Usage.Use();
 
             Console.WriteLine("Press any key to exit...");
             Console.ReadKey();


### PR DESCRIPTION
Hi, I've read your blog post and decided to try working the tpl pipelines design.

Did my best to avoid:
 - object boxing/unboxing
 - specifying generics
 - passing generics back and forth

this is the usage I've ended up with:
```
            var mgPipeline = new TplAsyncPipelineBuilder<string>()
                .AddStep(str => FindMostCommonAsync(str))
                .AddStep(str => CountChars(str))
                .AddStep(len => IsOdd(len))
                .Build();

            var result = await mgPipeline.Execute(exampleStr);
```

It separates builder from the class being build, and therefore avoids the need to pass generics and/or builder instance. 

I'm aware "sync" version is not the first-class citizen here, but did the simplification for code brevity. 
Also, proper exception handling is lacking but this should be fairly easy to improve

Please let me know what you think :)